### PR TITLE
Feature/optimize maths

### DIFF
--- a/include/baudvine/ringbuf/deque_ringbuf.h
+++ b/include/baudvine/ringbuf/deque_ringbuf.h
@@ -24,7 +24,7 @@ namespace baudvine {
 
 // A ring buffer based on std::deque. Inefficient, but compact and easily
 // verifiable.
-template <typename Elem, size_t Capacity>
+template <typename Elem, std::size_t Capacity>
 class DequeRingBuf {
  public:
   using value_type = Elem;

--- a/include/baudvine/ringbuf/deque_ringbuf.h
+++ b/include/baudvine/ringbuf/deque_ringbuf.h
@@ -53,9 +53,8 @@ class DequeRingBuf {
 
   bool empty() const { return data_.empty(); }
   size_type size() const { return data_.size(); }
-  size_type max_size() const { return data_.max_size(); }
-  size_type capacity() const { return Capacity; }
-  void shrink_to_fit() { return data_.shrink_to_fit(); }
+  constexpr size_type max_size() const { return capacity(); }
+  constexpr size_type capacity() const { return Capacity; }
 
   void clear() { return data_.clear(); }
 

--- a/include/baudvine/ringbuf/ringbuf.h
+++ b/include/baudvine/ringbuf/ringbuf.h
@@ -160,7 +160,10 @@ class RingBuf {
   using alloc = std::allocator<value_type>;
   using alloc_traits = std::allocator_traits<alloc>;
 
-  RingBuf() : data_(alloc_traits::allocate(alloc_, Capacity)){};
+  RingBuf()
+      : data_(alloc_traits::allocate(alloc_, Capacity)),
+        next_(data_),
+        end_(data_ + Capacity){};
   ~RingBuf() {
     while (!empty()) {
       pop_front();
@@ -187,6 +190,8 @@ class RingBuf {
   RingBuf& operator=(RingBuf&& other) noexcept {
     std::swap(alloc_, other.alloc_);
     std::swap(data_, other.data_);
+    std::swap(next_, other.next_);
+    std::swap(end_, other.end_);
     std::swap(base_, other.base_);
     std::swap(size_, other.size_);
     return *this;
@@ -256,8 +261,7 @@ class RingBuf {
       pop_front();
     }
 
-    alloc_traits::construct(alloc_, &data_[GetNext()],
-                            std::forward<Args>(args)...);
+    alloc_traits::construct(alloc_, next_, std::forward<Args>(args)...);
     Progress();
   }
 
@@ -325,13 +329,18 @@ class RingBuf {
  private:
   alloc alloc_{};
   pointer data_{nullptr};
+  pointer next_{nullptr};
+  pointer end_{nullptr};
   size_type base_{0U};
   size_type size_{0U};
 
-  size_type GetNext() { return detail::RingWrap<Capacity>(base_ + size_); }
-
   // Move things around after growing.
   void Progress() {
+    next_++;
+    if (next_ == end_) {
+      next_ -= Capacity;
+    }
+
     // The base only moves when we're full.
     if (size_ == Capacity) {
       base_ = detail::RingWrap<Capacity>(base_ + 1);

--- a/test/test_container.cpp
+++ b/test/test_container.cpp
@@ -113,8 +113,8 @@ TYPED_TEST_P(Container, Empty) {
 }
 
 TYPED_TEST_P(Container, Swap) {
-  auto a = TypeParam{};
-  auto b = TypeParam{};
+  TypeParam a;
+  TypeParam b;
 
   a.push_back(2010);
   a.push_back(3030);
@@ -131,6 +131,20 @@ TYPED_TEST_P(Container, Swap) {
   EXPECT_EQ(b, a2);
 }
 
+TYPED_TEST_P(Container, BeginEnd) {
+  TypeParam underTest;
+
+  underTest.push_back(4);
+  underTest.push_back(3);
+  EXPECT_EQ(std::next(underTest.begin(), 2), underTest.end());
+
+  underTest.push_back(2);
+  EXPECT_EQ(std::next(underTest.begin(), 3), underTest.end());
+
+  underTest.push_back(1);
+  EXPECT_EQ(std::next(underTest.begin(), 3), underTest.end());
+}
+
 REGISTER_TYPED_TEST_SUITE_P(Container,
                             CopyCtor,
                             MoveCtor,
@@ -140,7 +154,8 @@ REGISTER_TYPED_TEST_SUITE_P(Container,
                             Size,
                             MaxSize,
                             Empty,
-                            Swap);
+                            Swap,
+                            BeginEnd);
 using Containers =
     ::testing::Types<baudvine::RingBuf<int, 3>, baudvine::DequeRingBuf<int, 3>>;
 INSTANTIATE_TYPED_TEST_SUITE_P(My, Container, Containers);


### PR DESCRIPTION
Doesn't actually optimize any maths, just adds some tests and cleanup I ran into while _trying_ to optimize the maths.

For future reference: the "allocate Capacity + 1 and use the extra for the end() iterator" approach only makes things slower, I'm guessing because it introduces some branching that wasn't there before.