### PR TITLE
Feature/optimized copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ typical implementation of std::vector doesn't adhere to this, and if you've ever
 tried reading those you know what I mean.
 
 - Don't want to bother with optional features based on C++ version. Strictly C++11.
-- No debug-only runtime checks.
+- No debug-only runtime checks, other than the occasional `assert`.
 
 ## Performance
 

--- a/include/baudvine/ringbuf/ringbuf.h
+++ b/include/baudvine/ringbuf/ringbuf.h
@@ -150,6 +150,8 @@ class Iterator {
   }
 
   template <typename E, std::size_t C, typename OutputIt>
+  // https://github.com/llvm/llvm-project/issues/47430
+  // NOLINTNEXTLINE(readability-redundant-declaration)
   friend OutputIt copy(const Iterator<E, C>& begin,
                        const Iterator<E, C>& end,
                        OutputIt out);

--- a/include/baudvine/ringbuf/ringbuf.h
+++ b/include/baudvine/ringbuf/ringbuf.h
@@ -170,28 +170,17 @@ OutputIt copy(const Iterator<Elem, Capacity>& begin,
               OutputIt out) {
   assert(begin <= end);
 
-  // The length of the contiguous section to copy that starts at `begin`.
-  ptrdiff_t beginLength;
-  // The length of the contiguous section to copy that ends at `end`, or 0 if
-  // [begin, end) is contiguous.
-  ptrdiff_t endLength;
-
   if (begin == end) {
-    // Empty range.
-    beginLength = 0;
-    endLength = 0;
+    // Empty range, pass
   } else if (&*end > &*begin) {
     // Fully contiguous range.
-    beginLength = &*end - &*begin;
-    endLength = 0;
+    out = std::copy(&*begin, &*end, out);
   } else {
     // Copy in two sections.
-    beginLength = &begin.data_[Capacity] - &*begin;
-    endLength = &*end - end.data_;
+    out = std::copy(&*begin, &begin.data_[Capacity], out);
+    out = std::copy(end.data_, &*end, out);
   }
 
-  out = std::copy(&*begin, &*begin + beginLength, out);
-  out = std::copy(end.data_, end.data_ + endLength, out);
   return out;
 }
 

--- a/include/baudvine/ringbuf/ringbuf.h
+++ b/include/baudvine/ringbuf/ringbuf.h
@@ -126,6 +126,18 @@ class Iterator {
            std::tie(rhs.data_, rhs.ring_offset_, rhs.ring_index_);
   }
 
+  friend bool operator>(const Iterator& lhs, const Iterator& rhs) noexcept {
+    return rhs < lhs;
+  }
+
+  friend bool operator<=(const Iterator& lhs, const Iterator& rhs) noexcept {
+    return !(rhs < lhs);
+  }
+
+  friend bool operator>=(const Iterator& lhs, const Iterator& rhs) noexcept {
+    return !(lhs < rhs);
+  }
+
   friend bool operator==(const Iterator& lhs, const Iterator& rhs) noexcept {
     // Comparison via std::tie is very slow in debug builds, eating into
     // range-for cycle time.

--- a/test/examples.cpp
+++ b/test/examples.cpp
@@ -55,3 +55,22 @@ TEST(Example, RangeFor) {
     expected--;
   }
 }
+
+TEST(Example, Copy) {
+  // std::copy is slowish with RingBuf - it has to step through the iterators
+  // one by one as it doesn't know there are at worst two contiguous sections.
+  // Enter baudvine::copy(), which does.
+
+  baudvine::RingBuf<int, 3> buffer;
+  std::vector<int> vec(4);
+
+  buffer.push_back(4);
+  buffer.push_back(5);
+  buffer.push_back(6);
+  buffer.push_back(7);
+
+  baudvine::copy(buffer.begin(), buffer.end(), vec.begin());
+  // or more concisely thanks to ADL:
+  copy(buffer.begin(), buffer.end(), vec.begin());
+  EXPECT_THAT(vec, testing::ElementsAre(5, 6, 7, 0));
+}

--- a/test/test_iterator.cpp
+++ b/test/test_iterator.cpp
@@ -108,4 +108,22 @@ TEST(IteratorSta, Copy) {
   copy.clear();
   baudvine::copy(underTest.begin(), underTest.end(), std::back_inserter(copy));
   EXPECT_THAT(copy, testing::ElementsAre("5"));
+
+  underTest.pop_back();
+  copy.clear();
+  baudvine::copy(underTest.begin(), underTest.end(), std::back_inserter(copy));
+  EXPECT_THAT(copy, testing::ElementsAre());
+}
+
+TEST(IteratorSta, CopyAdl) {
+  // Check for argument-dependent lookup of baudvine::copy. This test only uses
+  // iterators from the baudvine namespace to suppress std::copy.
+
+  baudvine::RingBuf<int, 3> a;
+  baudvine::RingBuf<int, 4> b;
+  std::fill_n(std::back_inserter(b), b.max_size(), 0);
+
+  a.push_back(4);
+  copy(a.begin(), a.end(), b.begin());
+  EXPECT_THAT(b, testing::ElementsAre(4, 0, 0, 0));
 }

--- a/test/test_iterator.cpp
+++ b/test/test_iterator.cpp
@@ -102,4 +102,10 @@ TEST(IteratorSta, Copy) {
   copy.clear();
   baudvine::copy(underTest.begin(), underTest.end(), std::back_inserter(copy));
   EXPECT_THAT(copy, testing::ElementsAre("4", "5", "6"));
+
+  underTest.pop_front();
+  underTest.pop_back();
+  copy.clear();
+  baudvine::copy(underTest.begin(), underTest.end(), std::back_inserter(copy));
+  EXPECT_THAT(copy, testing::ElementsAre("5"));
 }

--- a/test/test_iterator.cpp
+++ b/test/test_iterator.cpp
@@ -2,6 +2,7 @@
 // https://en.cppreference.com/w/cpp/named_req/BidirectionalIterator
 
 #include <baudvine/ringbuf/ringbuf.h>
+#include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
 #include <type_traits>
@@ -72,4 +73,33 @@ TEST(IteratorSta, RangeFor) {
     EXPECT_EQ(expected, val);
     expected--;
   }
+}
+
+TEST(IteratorSta, Copy) {
+  baudvine::RingBuf<std::string, 3> underTest;
+  std::vector<std::string> copy;
+
+  baudvine::copy(underTest.begin(), underTest.end(), std::back_inserter(copy));
+  EXPECT_THAT(copy, testing::ElementsAre());
+
+  underTest.push_back("1");
+  baudvine::copy(underTest.begin(), underTest.end(), std::back_inserter(copy));
+  EXPECT_THAT(copy, testing::ElementsAre("1"));
+
+  underTest.push_back("2");
+  underTest.push_back("3");
+  copy.clear();
+  baudvine::copy(underTest.begin(), underTest.end(), std::back_inserter(copy));
+  EXPECT_THAT(copy, testing::ElementsAre("1", "2", "3"));
+
+  underTest.push_back("4");
+  underTest.push_back("5");
+  copy.clear();
+  baudvine::copy(underTest.begin(), underTest.end(), std::back_inserter(copy));
+  EXPECT_THAT(copy, testing::ElementsAre("3", "4", "5"));
+
+  underTest.push_back("6");
+  copy.clear();
+  baudvine::copy(underTest.begin(), underTest.end(), std::back_inserter(copy));
+  EXPECT_THAT(copy, testing::ElementsAre("4", "5", "6"));
 }

--- a/test/test_speed.cpp
+++ b/test/test_speed.cpp
@@ -110,3 +110,25 @@ TEST(Speed, IterateOver) {
   std::cout << "RingBuf:      " << standardDuration << std::endl;
   std::cout << "DequeRingBuf: " << dequeDuration << std::endl;
 }
+
+TEST(Speed, Copy) {
+  // baudvine::copy should be faster than std::copy as std::copy doesn't know that there are at most two contiguous sections.
+  baudvine::RingBuf<int, kTestSize> underTest;
+  std::fill_n(std::back_inserter(underTest), kTestSize, 55);
+
+  std::vector<int> copy;
+  copy.reserve(kTestSize);
+  std::fill_n(std::back_inserter(copy), kTestSize, 44);
+
+  auto customTime = TimeIt([&underTest, &copy] {
+    baudvine::copy(underTest.begin(), underTest.end(), copy.begin());
+  });
+
+  auto standardTime = TimeIt([&underTest, &copy] {
+    std::copy(underTest.begin(), underTest.end(), copy.begin());
+  });
+
+  EXPECT_LT(customTime, standardTime);
+  std::cout << "baudvine::copy: " << customTime << std::endl;
+  std::cout << "std::copy:      " << standardTime << std::endl;
+}

--- a/test/test_speed.cpp
+++ b/test/test_speed.cpp
@@ -112,7 +112,8 @@ TEST(Speed, IterateOver) {
 }
 
 TEST(Speed, Copy) {
-  // baudvine::copy should be faster than std::copy as std::copy doesn't know that there are at most two contiguous sections.
+  // baudvine::copy should be faster than std::copy as std::copy doesn't know
+  // that there are at most two contiguous sections.
   baudvine::RingBuf<int, kTestSize> underTest;
   std::fill_n(std::back_inserter(underTest), kTestSize, 55);
 


### PR DESCRIPTION
Adds baudvine::copy which works out to be about twice as fast (on a good day) as std:copy, as it knows about the internal structure of the ring buffer.