### PR TITLE
C++20/23 tests

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -51,8 +51,9 @@ jobs:
       matrix:
         platform: [Win32, x64]
         cxx_version: [11, 20]
+        runs-on: [windows-latest, windows-2022]
 
-    runs-on: windows-2022
+    runs-on: ${{matrix.runs-on}}
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     strategy:
       matrix:
-        cxx: [clang++, g++-10]
+        cxx: [clang++, g++]
         cxx_version: [11, 20]
 
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
@@ -52,7 +52,7 @@ jobs:
         platform: [Win32, x64]
         cxx_version: [11, 20]
 
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     strategy:
       matrix:
-        cxx: [clang++, g++]
+        cxx: [clang++, g++-10]
         cxx_version: [11, 20]
 
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -50,10 +50,9 @@ jobs:
     strategy:
       matrix:
         platform: [Win32, x64]
-        cxx_version: [11, 20]
-        runs-on: [windows-latest, windows-2022]
+        cxx_version: [11, 23]
 
-    runs-on: ${{matrix.runs-on}}
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 build
 .vscode
 .cache
+.vs
+CMakeSettings.json

--- a/include/baudvine/ringbuf/ringbuf.h
+++ b/include/baudvine/ringbuf/ringbuf.h
@@ -40,6 +40,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
+#include <iterator>
 #include <stdexcept>
 #include <tuple>
 
@@ -76,7 +77,7 @@ class Iterator {
   using value_type = Elem;
   using pointer = Elem*;
   using reference = Elem&;
-  using iterator_category = std::forward_iterator_tag;
+  using iterator_category = std::bidirectional_iterator_tag;
 
   constexpr Iterator() noexcept = default;
   /**
@@ -116,6 +117,17 @@ class Iterator {
 
   Iterator& operator++() noexcept {
     ++ring_index_;
+    return *this;
+  }
+
+  Iterator operator--(int) noexcept {
+    Iterator copy(*this);
+    operator--();
+    return copy;
+  }
+
+  Iterator& operator--() noexcept {
+    --ring_index_;
     return *this;
   }
 

--- a/test/config.h
+++ b/test/config.h
@@ -1,0 +1,33 @@
+#pragma once
+
+// While the RingBuf implementation is free of version-dependent implementation
+// details, the tests need to work on C++11 and all newer versions, and it's
+// okay for some of the tests to only work on e.g. C++17.
+
+// First determine the language version.
+
+#define BAUDVINE_CXX14 201402L
+#define BAUDVINE_CXX17 201703L
+#define BAUDVINE_CXX20 202002L
+
+#ifdef _MSVC_LANG
+#define BAUDVINE_CPLUSPLUS _MSVC_LANG
+#else
+#define BAUDVINE_CPLUSPLUS __cplusplus
+#endif
+
+#if BAUDVINE_CPLUSPLUS >= BAUDVINE_CXX14
+#define BAUDVINE_HAVE_CXX14 1
+#endif
+#if BAUDVINE_CPLUSPLUS >= BAUDVINE_CXX17
+#define BAUDVINE_HAVE_CXX17 1
+#endif
+#if BAUDVINE_CPLUSPLUS >= BAUDVINE_CXX20
+#define BAUDVINE_HAVE_CXX20 1
+#endif
+
+// Feature tests:
+
+#ifdef BAUDVINE_HAVE_CXX17
+#define BAUDVINE_HAVE_VARIANT 1
+#endif

--- a/test/config.h
+++ b/test/config.h
@@ -40,9 +40,11 @@
 // to 11.2 (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100900)
 #if __has_include(<bits/c++config.h>)
 #include <bits/c++config.h>
-#define BAUDVINE_HAVE_RANGES (__GLIBCXX__ >= 20210708L)
+#if __GLIBCXX__ >= 20210708L
+#define BAUDVINE_HAVE_RANGES 1
+#endif  // __GLIBCXX__
 #endif  // <bits/c++config.h>
-#else
-#define BAUDVINE_HAVE_RANGES (__cpp_lib_ranges >= 201911L)
+#elif __cpp_lib_ranges >= 201911L
+#define BAUDVINE_HAVE_RANGES 1
 #endif  // __clang__
 #endif  // BAUDVINE_HAVE_CXX20

--- a/test/config.h
+++ b/test/config.h
@@ -31,3 +31,11 @@
 #ifdef BAUDVINE_HAVE_CXX17
 #define BAUDVINE_HAVE_VARIANT 1
 #endif
+
+#ifdef BAUDVINE_HAVE_CXX20
+#include <version>
+
+#if __cpp_lib_ranges >= 201911L
+#define BAUDVINE_HAVE_RANGES 1
+#endif
+#endif

--- a/test/config.h
+++ b/test/config.h
@@ -35,7 +35,16 @@
 #ifdef BAUDVINE_HAVE_CXX20
 #include <version>
 
-#if __cpp_lib_ranges >= 201911L
+#if defined(__clang__) && __clang_major__ <= 13
+// Clang 13 has some issues with <ranges> in gcc's standard library prior
+// to 11.2 (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100900)
+#if __has_include(<bits/c++config.h>)
+#include <bits/c++config.h>
+#if __GLIBCXX__ >= 20210708L
 #define BAUDVINE_HAVE_RANGES 1
-#endif
-#endif
+#endif  // __GLIBCXX__
+#endif  // <bits/c++config.h>
+#elif __cpp_lib_ranges >= 201911L
+#define BAUDVINE_HAVE_RANGES 1
+#endif  // __clang__
+#endif  // BAUDVINE_HABE_CXX20

--- a/test/config.h
+++ b/test/config.h
@@ -40,11 +40,9 @@
 // to 11.2 (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100900)
 #if __has_include(<bits/c++config.h>)
 #include <bits/c++config.h>
-#if __GLIBCXX__ >= 20210708L
-#define BAUDVINE_HAVE_RANGES 1
-#endif  // __GLIBCXX__
+#define BAUDVINE_HAVE_RANGES (__GLIBCXX__ >= 20210708L)
 #endif  // <bits/c++config.h>
-#elif __cpp_lib_ranges >= 201911L
-#define BAUDVINE_HAVE_RANGES 1
+#else
+#define BAUDVINE_HAVE_RANGES (__cpp_lib_ranges >= 201911L)
 #endif  // __clang__
-#endif  // BAUDVINE_HABE_CXX20
+#endif  // BAUDVINE_HAVE_CXX20

--- a/test/config.h
+++ b/test/config.h
@@ -35,15 +35,13 @@
 #ifdef BAUDVINE_HAVE_CXX20
 #include <version>
 
-#if defined(__clang__) && __clang_major__ <= 13
-// Clang 13 has some issues with <ranges> in gcc's standard library prior
-// to 11.2 (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100900)
-#if __has_include(<bits/c++config.h>)
+#if defined(__clang__) && __clang_major__ <= 13 && __has_include(<bits/c++config.h>)
+// Clang 13 has some issues with <ranges> in gcc's standard library < 11.2
+// (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100900)
 #include <bits/c++config.h>
 #if __GLIBCXX__ >= 20210708L
 #define BAUDVINE_HAVE_RANGES 1
 #endif  // __GLIBCXX__
-#endif  // <bits/c++config.h>
 #elif __cpp_lib_ranges >= 201911L
 #define BAUDVINE_HAVE_RANGES 1
 #endif  // __clang__

--- a/test/ringbuf_adapter.h
+++ b/test/ringbuf_adapter.h
@@ -1,9 +1,15 @@
 #pragma once
 
+#include "config.h"
+
+#ifdef BAUDVINE_HAVE_VARIANT
+#define BAUDVINE_HAVE_RINGBUF_ADAPTER
+
 #include <baudvine/ringbuf/deque_ringbuf.h>
 #include <baudvine/ringbuf/ringbuf.h>
 
 #include <ostream>
+#include <variant>
 
 enum class Variant {
   Standard,
@@ -20,12 +26,21 @@ inline std::ostream& operator<<(std::ostream& os, Variant variant) {
 template <typename Elem, std::size_t Capacity>
 class RingBufAdapter {
  public:
-  RingBufAdapter(Variant variant) : variant_(variant) {}
+  RingBufAdapter(Variant variant) {
+    switch (variant) {
+      case Variant::Standard:
+        ringbuf_.template emplace<baudvine::RingBuf<Elem, Capacity>>();
+        break;
+      case Variant::Deque:
+        ringbuf_.template emplace<baudvine::DequeRingBuf<Elem, Capacity>>();
+        break;
+    }
+  }
 
 #define DISPATCH(call) \
-  variant_ == Variant::Standard ? static_.call : dynamic_.call
+  std::visit([&](auto&& b) -> decltype(auto) { return b.call; }, ringbuf_)
 
-  Elem& front() { return DISPATCH(front()); }
+  Elem& front() { return std::visit([](auto&& b) -> decltype(auto) { return b.front(); }, ringbuf_); }
   Elem& back() { return DISPATCH(back()); }
   Elem& operator[](size_t index) { return DISPATCH(operator[](index)); }
   const Elem& operator[](size_t index) const {
@@ -55,32 +70,25 @@ class RingBufAdapter {
   bool empty() { return DISPATCH(empty()); }
 
   friend bool operator<(const RingBufAdapter& lhs, const RingBufAdapter& rhs) {
-    return lhs.variant_ == Variant::Standard ? lhs.static_ < rhs.static_
-                                             : lhs.dynamic_ < rhs.dynamic_;
+    return lhs.ringbuf_ < rhs.ringbuf_;
   }
 
   friend bool operator==(const RingBufAdapter& lhs, const RingBufAdapter& rhs) {
-    return lhs.variant_ == Variant::Standard ? lhs.static_ == rhs.static_
-                                             : lhs.dynamic_ == rhs.dynamic_;
+    return lhs.ringbuf_ == rhs.ringbuf_;
   }
 
   friend bool operator!=(const RingBufAdapter& lhs, const RingBufAdapter& rhs) {
-    return lhs.variant_ == Variant::Standard ? lhs.static_ != rhs.static_
-                                             : lhs.dynamic_ != rhs.dynamic_;
+    return lhs.ringbuf_ != rhs.ringbuf_;
   }
 
   void swap(RingBufAdapter& other) {
-    return variant_ == Variant::Standard ? static_.swap(other.static_)
-                                         : dynamic_.swap(other.dynamic_);
+    return ringbuf_.swap(other.ringbuf_);
   }
 
 #undef DISPATCH
 
  private:
-  Variant variant_;
-
-  // This would be less annoying with std::variant, but the build should also
-  // run with C++11.
-  baudvine::RingBuf<Elem, Capacity> static_{};
-  baudvine::DequeRingBuf<Elem, Capacity> dynamic_{};
+  std::variant<baudvine::RingBuf<Elem, Capacity>, baudvine::DequeRingBuf<Elem, Capacity>> ringbuf_;
 };
+
+#endif // BAUDVINE_HAVE_VARIANT

--- a/test/ringbuf_adapter.h
+++ b/test/ringbuf_adapter.h
@@ -40,7 +40,7 @@ class RingBufAdapter {
 #define DISPATCH(call) \
   std::visit([&](auto&& b) -> decltype(auto) { return b.call; }, ringbuf_)
 
-  Elem& front() { return std::visit([](auto&& b) -> decltype(auto) { return b.front(); }, ringbuf_); }
+  Elem& front() { return DISPATCH(front()); }
   Elem& back() { return DISPATCH(back()); }
   Elem& operator[](size_t index) { return DISPATCH(operator[](index)); }
   const Elem& operator[](size_t index) const {
@@ -81,14 +81,14 @@ class RingBufAdapter {
     return lhs.ringbuf_ != rhs.ringbuf_;
   }
 
-  void swap(RingBufAdapter& other) {
-    return ringbuf_.swap(other.ringbuf_);
-  }
+  void swap(RingBufAdapter& other) { return ringbuf_.swap(other.ringbuf_); }
 
 #undef DISPATCH
 
  private:
-  std::variant<baudvine::RingBuf<Elem, Capacity>, baudvine::DequeRingBuf<Elem, Capacity>> ringbuf_;
+  std::variant<baudvine::RingBuf<Elem, Capacity>,
+               baudvine::DequeRingBuf<Elem, Capacity>>
+      ringbuf_;
 };
 
-#endif // BAUDVINE_HAVE_VARIANT
+#endif  // BAUDVINE_HAVE_VARIANT

--- a/test/test_container.cpp
+++ b/test/test_container.cpp
@@ -17,8 +17,7 @@ class Container : public testing::Test {};
 TYPED_TEST_SUITE_P(Container);
 
 #ifdef BAUDVINE_HAVE_RANGES
-TYPED_TEST_P(Container, IsRandomAccessRange)
-{
+TYPED_TEST_P(Container, IsRandomAccessRange) {
   EXPECT_TRUE(std::ranges::random_access_range<TypeParam>);
 }
 #endif

--- a/test/test_container.cpp
+++ b/test/test_container.cpp
@@ -3,24 +3,13 @@
 
 #include "baudvine/ringbuf/deque_ringbuf.h"
 #include "baudvine/ringbuf/ringbuf.h"
-#include "config.h"
 
 #include <gtest/gtest.h>
-
-#ifdef BAUDVINE_HAVE_RANGES
-#include <ranges>
-#endif
 
 template <typename RingBuf>
 class Container : public testing::Test {};
 
 TYPED_TEST_SUITE_P(Container);
-
-#ifdef BAUDVINE_HAVE_RANGES
-TYPED_TEST_P(Container, IsRandomAccessRange) {
-  EXPECT_TRUE(std::ranges::random_access_range<TypeParam>);
-}
-#endif
 
 TYPED_TEST_P(Container, CopyCtor) {
   TypeParam original;
@@ -157,9 +146,6 @@ TYPED_TEST_P(Container, BeginEnd) {
 }
 
 REGISTER_TYPED_TEST_SUITE_P(Container,
-#ifdef BAUDVINE_HAVE_RANGES
-                            IsRandomAccessRange,
-#endif
                             CopyCtor,
                             MoveCtor,
                             Assignment,

--- a/test/test_container.cpp
+++ b/test/test_container.cpp
@@ -3,13 +3,25 @@
 
 #include "baudvine/ringbuf/deque_ringbuf.h"
 #include "baudvine/ringbuf/ringbuf.h"
+#include "config.h"
 
 #include <gtest/gtest.h>
+
+#ifdef BAUDVINE_HAVE_RANGES
+#include <ranges>
+#endif
 
 template <typename RingBuf>
 class Container : public testing::Test {};
 
 TYPED_TEST_SUITE_P(Container);
+
+#ifdef BAUDVINE_HAVE_RANGES
+TYPED_TEST_P(Container, IsRandomAccessRange)
+{
+  EXPECT_TRUE(std::ranges::random_access_range<TypeParam>);
+}
+#endif
 
 TYPED_TEST_P(Container, CopyCtor) {
   TypeParam original;
@@ -146,6 +158,9 @@ TYPED_TEST_P(Container, BeginEnd) {
 }
 
 REGISTER_TYPED_TEST_SUITE_P(Container,
+#ifdef BAUDVINE_HAVE_RANGES
+                            IsRandomAccessRange,
+#endif
                             CopyCtor,
                             MoveCtor,
                             Assignment,

--- a/test/test_container_ranges.cpp
+++ b/test/test_container_ranges.cpp
@@ -14,14 +14,14 @@ class ContainerRanges : public testing::Test {};
 
 TYPED_TEST_SUITE_P(ContainerRanges);
 
-TYPED_TEST_P(ContainerRanges, IsRandomAccessRange) {
-  EXPECT_TRUE(std::ranges::random_access_range<TypeParam>);
+TYPED_TEST_P(ContainerRanges, IsBidiRange) {
+  EXPECT_TRUE(std::ranges::bidirectional_range<TypeParam>);
 }
 
-REGISTER_TYPED_TEST_SUITE_P(ContainerRanges, IsRandomAccessRange);
+REGISTER_TYPED_TEST_SUITE_P(ContainerRanges, IsBidiRange);
 
 using Containers =
     ::testing::Types<baudvine::RingBuf<int, 3>, baudvine::DequeRingBuf<int, 3>>;
 INSTANTIATE_TYPED_TEST_SUITE_P(My, ContainerRanges, Containers);
 
-#endif // BAUDVINE_HAVE_RANGES
+#endif  // BAUDVINE_HAVE_RANGES

--- a/test/test_container_ranges.cpp
+++ b/test/test_container_ranges.cpp
@@ -1,0 +1,27 @@
+#include "baudvine/ringbuf/deque_ringbuf.h"
+#include "baudvine/ringbuf/ringbuf.h"
+#include "config.h"
+
+#include <gtest/gtest-typed-test.h>
+#include <gtest/gtest.h>
+
+#ifdef BAUDVINE_HAVE_RANGES
+
+#include <ranges>
+
+template <typename RingBuf>
+class ContainerRanges : public testing::Test {};
+
+TYPED_TEST_SUITE_P(ContainerRanges);
+
+TYPED_TEST_P(ContainerRanges, IsRandomAccessRange) {
+  EXPECT_TRUE(std::ranges::random_access_range<TypeParam>);
+}
+
+REGISTER_TYPED_TEST_SUITE_P(ContainerRanges, IsRandomAccessRange);
+
+using Containers =
+    ::testing::Types<baudvine::RingBuf<int, 3>, baudvine::DequeRingBuf<int, 3>>;
+INSTANTIATE_TYPED_TEST_SUITE_P(My, ContainerRanges, Containers);
+
+#endif // BAUDVINE_HAVE_RANGES

--- a/test/test_ringbuf.cpp
+++ b/test/test_ringbuf.cpp
@@ -5,6 +5,8 @@
 
 #include <memory>
 
+#ifdef BAUDVINE_HAVE_RINGBUF_ADAPTER
+
 class RingBuf : public testing::TestWithParam<Variant> {
  public:
   template <typename Elem, size_t Capacity>
@@ -259,3 +261,5 @@ TEST_P(RingBuf, Clear) {
 INSTANTIATE_TEST_SUITE_P(RingBuf,
                          RingBuf,
                          testing::Values(Variant::Standard, Variant::Deque));
+
+#endif  // BAUDVINE_HAVE_RINGBUF_ADAPTER


### PR DESCRIPTION
This adds some feature-testing to allow some tests to be built only in C++20/23 mode. It also upgrades the iterator to bidirectional, and adds a test to verify that RingBuf is std::ranges::bidirectional_range.