### PR TITLE
Feature/compiler warnings (+ allocator test fixes)

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -46,7 +46,7 @@ jobs:
 
     - name: Test
       working-directory: ${{github.workspace}}/build
-      # Execute tests defined by the CMake configuration.  
+      # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       # Speed.* are disabled because some of them are right on the edge, and it
       # depends on system load besides.
@@ -64,11 +64,12 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Configure CMake
+      # The /EHsc compiler flag is set by default unless you set CMAKE_CXX_FLAGS
       run: >
         cmake -B ${{github.workspace}}/build
         -A ${{matrix.platform}}
         -DCMAKE_CXX_STANDARD=${{matrix.cxx_version}}
-        -DCMAKE_CXX_FLAGS="/WX"
+        -DCMAKE_CXX_FLAGS="/WX /EHsc"
         -Dgtest_force_shared_crt=ON
 
     - name: Build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -38,6 +38,7 @@ jobs:
         -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
         -DCMAKE_CXX_COMPILER=${{matrix.cxx}}
         -DCMAKE_CXX_STANDARD=${{matrix.cxx_version}}
+        -DCMAKE_CXX_FLAGS="-Werror"
 
     - name: Build
       # Build your program with the given configuration
@@ -67,6 +68,7 @@ jobs:
         cmake -B ${{github.workspace}}/build
         -A ${{matrix.platform}}
         -DCMAKE_CXX_STANDARD=${{matrix.cxx_version}}
+        -DCMAKE_CXX_FLAGS="/WX"
         -Dgtest_force_shared_crt=ON
 
     - name: Build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -64,12 +64,13 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Configure CMake
-      # The /EHsc compiler flag is set by default unless you set CMAKE_CXX_FLAGS
+      # The /EHsc /GR flags are ~ the default value of CMAKE_CXX_FLAGS.
+      # https://gitlab.kitware.com/cmake/cmake/-/issues/20610
       run: >
         cmake -B ${{github.workspace}}/build
         -A ${{matrix.platform}}
         -DCMAKE_CXX_STANDARD=${{matrix.cxx_version}}
-        -DCMAKE_CXX_FLAGS="/WX /EHsc"
+        -DCMAKE_CXX_FLAGS="/WX /GR /EHsc"
         -Dgtest_force_shared_crt=ON
 
     - name: Build

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -24,6 +24,7 @@ jobs:
         cmake -B ${{github.workspace}}/build
         -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
         -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+        -DCMAKE_CXX_STANDARD=11
 
     - name: Run clang-tidy
       run: >

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,25 +10,29 @@ target_include_directories(baudvine-ringbuf INTERFACE include)
 target_compile_features(baudvine-ringbuf INTERFACE cxx_std_11)
 
 if (MSVC)
-  add_compile_options(/W4)
-else()
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror=return-type)
-endif()
+    add_compile_options(
+            /W4
+            # C4127 "conditional expression is constant" - don't have `if constexpr` in c++11
+            /wd4127
+    )
+else ()
+    add_compile_options(-Wall -Wextra -Wpedantic -Werror=return-type)
+endif ()
 
 # Install configuration
 set_target_properties(baudvine-ringbuf
-  PROPERTIES
-  PUBLIC_HEADER include/baudvine/ringbuf/ringbuf.h
-  )
+        PROPERTIES
+        PUBLIC_HEADER include/baudvine/ringbuf/ringbuf.h
+        )
 include(GNUInstallDirs)
 install(
-  TARGETS baudvine-ringbuf
-  PUBLIC_HEADER
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/baudvine/ringbuf/
-  )
+        TARGETS baudvine-ringbuf
+        PUBLIC_HEADER
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/baudvine/ringbuf/
+)
 
 # Build the tests (or not)
 if (${RINGBUF_TESTS})
-  enable_testing()
-  add_subdirectory(test)
-endif()
+    enable_testing()
+    add_subdirectory(test)
+endif ()

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ What can't it do? Well:
 - [x] Document iterator invalidation.
 - [x] Compare to `boost::circular_buffer`
 - [ ] Special case for emplace/push members when T's lifetime doesn't matter (e.g. int)
-- [ ] Compiler warning cleanup
+- [x] Compiler warning cleanup
 - [ ] Compare to boost's spsc queue, which has optional ring buffer semantics.
 
 ### NOT TODO

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ What can't it do? Well:
 - [x] Compare to `boost::circular_buffer`
 - [ ] Special case for emplace/push members when T's lifetime doesn't matter (e.g. int)
 - [ ] Compiler warning cleanup
+- [ ] Compare to boost's spsc queue, which has optional ring buffer semantics.
 
 ### NOT TODO
 What won't it do?

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,23 +3,31 @@ add_executable(ringbuf-test)
 # Add test sources
 file(GLOB test_files "test_*.cpp")
 target_sources(ringbuf-test PRIVATE
-  examples.cpp
-  instance_counter.cpp
-  ${test_files}
-  )
+        examples.cpp
+        instance_counter.cpp
+        ${test_files}
+        )
 
 target_link_libraries(ringbuf-test PRIVATE baudvine-ringbuf)
 
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    target_compile_options(ringbuf-test PRIVATE
+            # Triggers on correct use of TYPED_TEST_SUITE
+            -Wno-gnu-zero-variadic-macro-arguments
+            )
+endif ()
+
 set_target_properties(ringbuf-test
-  PROPERTIES
-  CXX_EXTENSIONS OFF)
+        PROPERTIES
+        CXX_EXTENSIONS OFF
+        )
 
 # Wire up googletest
 include(FetchContent)
 FetchContent_Declare(
-  googletest
-  URL https://github.com/google/googletest/archive/refs/tags/release-1.11.0.tar.gz
-  )
+        googletest
+        URL https://github.com/google/googletest/archive/refs/tags/release-1.11.0.tar.gz
+)
 FetchContent_MakeAvailable(googletest)
 
 # googletest includes a default main() that's good enough here
@@ -31,21 +39,21 @@ gtest_discover_tests(ringbuf-test)
 
 find_package(Boost 1.67.0)
 if (Boost_FOUND)
-  # The allocator-aware tests use Boost's shared memory allocator.
-  target_link_libraries(ringbuf-test PRIVATE Boost::headers)
-  if (UNIX)
-    # need librt for shm_open & co
-    target_link_libraries(ringbuf-test PRIVATE rt)
-  endif()
-  target_compile_definitions(ringbuf-test PRIVATE BOOST_DATE_TIME_NO_LIB)
-  target_compile_definitions(ringbuf-test PRIVATE BAUDVINE_HAVE_BOOST_IPC)
-endif()
+    # The allocator-aware tests use Boost's shared memory allocator.
+    target_link_libraries(ringbuf-test PRIVATE Boost::headers)
+    if (UNIX)
+        # need librt for shm_open & co
+        target_link_libraries(ringbuf-test PRIVATE rt)
+    endif ()
+    target_compile_definitions(ringbuf-test PRIVATE BOOST_DATE_TIME_NO_LIB)
+    target_compile_definitions(ringbuf-test PRIVATE BAUDVINE_HAVE_BOOST_IPC)
+endif ()
 
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 try_compile(have_variant ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_LIST_DIR}/build_tools/feature_check_variant.cpp)
 try_compile(have_ranges ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_LIST_DIR}/build_tools/feature_check_ranges.cpp)
 
 target_compile_definitions(ringbuf-test PRIVATE
-  $<$<BOOL:${have_variant}>:BAUDVINE_HAVE_VARIANT>
-  $<$<BOOL:${have_ranges}>:BAUDVINE_HAVE_RANGES>
-  )
+        $<$<BOOL:${have_variant}>:BAUDVINE_HAVE_VARIANT>
+        $<$<BOOL:${have_ranges}>:BAUDVINE_HAVE_RANGES>
+        )

--- a/test/ringbufs.h
+++ b/test/ringbufs.h
@@ -7,10 +7,10 @@
 #include <gtest/internal/gtest-type-util.h>
 
 // All implementations including the adapter.
-template <typename T, size_t N>
-using AllRingBufs =
-    testing::Types<baudvine::RingBuf<T, N>, baudvine::DequeRingBuf<T, N>>;
+template <typename T, size_t N, typename Alloc = std::allocator<T>>
+using AllRingBufs = testing::Types<baudvine::RingBuf<T, N, Alloc>,
+                                   baudvine::DequeRingBuf<T, N, Alloc>>;
 
 // All completely local implementations.
-template <typename T, size_t N>
-using OurRingBufs = testing::Types<baudvine::RingBuf<T, N>>;
+template <typename T, size_t N, typename Alloc = std::allocator<T>>
+using OurRingBufs = testing::Types<baudvine::RingBuf<T, N, Alloc>>;

--- a/test/test_allocator_elementwise.cpp
+++ b/test/test_allocator_elementwise.cpp
@@ -4,8 +4,8 @@
 
 #include "at_exit.h"
 #include "instance_counter.h"
+#include "ringbufs.h"
 
-#include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
 #include <boost/interprocess/allocators/allocator.hpp>
@@ -21,10 +21,7 @@ template <typename T>
 using Allocator =
     ipc::allocator<T, ipc::managed_shared_memory::segment_manager>;
 
-using RingBufs = testing::Types<
-    baudvine::RingBuf<InstanceCounter, 2, Allocator<InstanceCounter>>,
-    baudvine::DequeRingBuf<InstanceCounter, 2, Allocator<InstanceCounter>>>;
-
+using RingBufs = AllRingBufs<InstanceCounter, 2, Allocator<InstanceCounter>>;
 // NOLINTNEXTLINE - clang-tidy complains about missing variadic args
 TYPED_TEST_SUITE(AllocatorElementwise, RingBufs);
 

--- a/test/test_container_alloc_aware.cpp
+++ b/test/test_container_alloc_aware.cpp
@@ -1,5 +1,4 @@
-#include "baudvine/ringbuf/deque_ringbuf.h"
-#include "baudvine/ringbuf/ringbuf.h"
+#include "ringbufs.h"
 
 #include <gtest/gtest.h>
 
@@ -12,11 +11,11 @@ template <typename RingBuf>
 class ContainerReqsAllocAware : public testing::Test {};
 
 template <typename T>
-using Allocator = std::scoped_allocator_adaptor<std::allocator<T>>;
+using Allocator =
+    std::scoped_allocator_adaptor<std::allocator<T>,
+                                  std::allocator<typename T::value_type>>;
 
-using RingBufs = testing::Types<
-    baudvine::RingBuf<std::string, 2, Allocator<std::string>>,
-    baudvine::DequeRingBuf<std::string, 2, Allocator<std::string>>>;
+using RingBufs = AllRingBufs<std::string, 2, Allocator<std::string>>;
 // NOLINTNEXTLINE - clang-tidy complains about missing variadic args
 TYPED_TEST_SUITE(ContainerReqsAllocAware, RingBufs);
 

--- a/test/test_container_alloc_aware.cpp
+++ b/test/test_container_alloc_aware.cpp
@@ -4,6 +4,7 @@
 
 #include <memory>
 #include <scoped_allocator>
+#include <vector>
 
 #define EXPECT_TYPE_EQ(T1, T2) EXPECT_TRUE((std::is_same<T1, T2>::value))
 
@@ -15,18 +16,21 @@ using Allocator =
     std::scoped_allocator_adaptor<std::allocator<T>,
                                   std::allocator<typename T::value_type>>;
 
-using RingBufs = AllRingBufs<std::string, 2, Allocator<std::string>>;
+using RingBufs = AllRingBufs<std::vector<int>, 2, Allocator<std::vector<int>>>;
 // NOLINTNEXTLINE - clang-tidy complains about missing variadic args
 TYPED_TEST_SUITE(ContainerReqsAllocAware, RingBufs);
 
 TYPED_TEST(ContainerReqsAllocAware, TypeAliases) {
-  EXPECT_TYPE_EQ(Allocator<std::string>, typename TypeParam::allocator_type);
+  EXPECT_TYPE_EQ(Allocator<std::vector<int>>,
+                 typename TypeParam::allocator_type);
 }
 
 TYPED_TEST(ContainerReqsAllocAware, GetAllocator) {
-  EXPECT_TYPE_EQ(Allocator<std::string>, decltype(TypeParam{}.get_allocator()));
+  EXPECT_TYPE_EQ(Allocator<std::vector<int>>,
+                 decltype(TypeParam{}.get_allocator()));
 }
 
 TYPED_TEST(ContainerReqsAllocAware, UsesAllocator) {
-  EXPECT_TRUE((std::uses_allocator<TypeParam, Allocator<std::string>>::value));
+  EXPECT_TRUE(
+      (std::uses_allocator<TypeParam, Allocator<std::vector<int>>>::value));
 }

--- a/test/test_container_alloc_ipc.cpp
+++ b/test/test_container_alloc_ipc.cpp
@@ -1,14 +1,14 @@
 #ifdef BAUDVINE_HAVE_BOOST_IPC
-#include "baudvine/ringbuf/deque_ringbuf.h"
-#include "baudvine/ringbuf/ringbuf.h"
-
 #include "at_exit.h"
+#include "ringbufs.h"
 
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
 #include <boost/interprocess/allocators/allocator.hpp>
 #include <boost/interprocess/managed_shared_memory.hpp>
+
+#include <scoped_allocator>
 
 // Allocator tests using Boost's shared memory allocator.
 template <typename RingBuf>
@@ -20,15 +20,35 @@ template <typename T>
 using Allocator =
     ipc::allocator<T, ipc::managed_shared_memory::segment_manager>;
 
-// In a real application, std::string would also need that allocator so the
-// actual string ends up in shared memory as well - but the generated test names
-// are long enough as it is.
-using RingBufs = testing::Types<
-    baudvine::RingBuf<std::string, 2, Allocator<std::string>>,
-    baudvine::DequeRingBuf<std::string, 2, Allocator<std::string>>>;
+// In a real application, this would be
+// std::scoped_allocator<
+//  Allocator<std::basic_string<char, std::char_traits<char>, Allocator<char>>>,
+//  Allocator<char>>
+// so the string contents are also allocated in the shared memory. The generated
+// test names are long enough as it is.
+using RingBufs = AllRingBufs<std::string, 2, Allocator<std::string>>;
 
 // NOLINTNEXTLINE - clang-tidy complains about missing variadic args
 TYPED_TEST_SUITE(ContainerReqsAllocIpc, RingBufs);
+
+TEST(ContainerReqsAllocIpcScoped, Create) {
+  // one-off, demonstrate that it works with scoped_allocator.
+  using Elem = std::vector<int, Allocator<int>>;
+  using ScopedAllocator =
+      std::scoped_allocator_adaptor<Allocator<Elem>, Allocator<int>>;
+  using RingBuf = baudvine::RingBuf<Elem, 4, ScopedAllocator>;
+
+  std::string name = std::string("Ipc-Scoped");
+  ipc::shared_memory_object::remove(name.c_str());
+  AtExit remove_shmem([&] { ipc::shared_memory_object::remove(name.c_str()); });
+  ipc::managed_shared_memory shm(ipc::create_only, name.c_str(), 1024);
+
+  RingBuf buffer(
+      ScopedAllocator(shm.get_segment_manager(), shm.get_segment_manager()));
+  EXPECT_EQ(buffer.emplace_back(4).size(), 4);
+  EXPECT_EQ(buffer.emplace_back(5).size(), 5);
+  EXPECT_EQ(buffer[0].get_allocator().get_segment_manager(), shm.get_segment_manager());
+}
 
 TYPED_TEST(ContainerReqsAllocIpc, Create) {
   std::string name = std::string("Ipc-") + typeid(TypeParam).name();

--- a/test/test_container_alloc_ipc.cpp
+++ b/test/test_container_alloc_ipc.cpp
@@ -47,7 +47,8 @@ TEST(ContainerReqsAllocIpcScoped, Create) {
       ScopedAllocator(shm.get_segment_manager(), shm.get_segment_manager()));
   EXPECT_EQ(buffer.emplace_back(4).size(), 4);
   EXPECT_EQ(buffer.emplace_back(5).size(), 5);
-  EXPECT_EQ(buffer[0].get_allocator().get_segment_manager(), shm.get_segment_manager());
+  EXPECT_EQ(buffer[0].get_allocator().get_segment_manager(),
+            shm.get_segment_manager());
 }
 
 TYPED_TEST(ContainerReqsAllocIpc, Create) {

--- a/test/test_container_concepts.cpp
+++ b/test/test_container_concepts.cpp
@@ -1,5 +1,4 @@
-#include "baudvine/ringbuf/deque_ringbuf.h"
-#include "baudvine/ringbuf/ringbuf.h"
+#include "ringbufs.h"
 
 #include <gtest/gtest-typed-test.h>
 #include <gtest/gtest.h>
@@ -11,8 +10,7 @@
 template <typename RingBuf>
 class ContainerConcepts : public testing::Test {};
 
-using RingBufs =
-    testing::Types<baudvine::RingBuf<int, 2>, baudvine::DequeRingBuf<int, 2>>;
+using RingBufs = AllRingBufs<int, 2>;
 // NOLINTNEXTLINE - clang-tidy complains about missing variadic args
 TYPED_TEST_SUITE(ContainerConcepts, RingBufs);
 

--- a/test/test_container_general.cpp
+++ b/test/test_container_general.cpp
@@ -1,7 +1,6 @@
-#include "baudvine/ringbuf/deque_ringbuf.h"
-#include "baudvine/ringbuf/ringbuf.h"
 #include "instance_counter.h"
 #include "ringbuf_adapter.h"
+#include "ringbufs.h"
 
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
@@ -37,8 +36,7 @@ class ContainerReqsGeneral : public testing::Test {
   RingBuf&& rv_ = std::move(r_);
 };
 
-using RingBufs =
-    testing::Types<baudvine::RingBuf<int, 2>, baudvine::DequeRingBuf<int, 2>>;
+using RingBufs = AllRingBufs<int, 2>;
 // NOLINTNEXTLINE - clang-tidy complains about missing variadic args
 TYPED_TEST_SUITE(ContainerReqsGeneral, RingBufs);
 

--- a/test/test_container_general.cpp
+++ b/test/test_container_general.cpp
@@ -17,24 +17,24 @@ template <typename RingBuf>
 class ContainerReqsGeneral : public testing::Test {
  public:
   void SetUp() override {
-    a.clear();
-    a.push_back(1);
-    a.push_back(2);
-    a.push_back(3);
-    b.clear();
-    b.push_back(3);
-    b.push_back(4);
-    b.push_back(5);
-    r.clear();
-    r.push_back(5);
-    r.push_back(6);
-    r.push_back(7);
+    a_.clear();
+    a_.push_back(1);
+    a_.push_back(2);
+    a_.push_back(3);
+    b_.clear();
+    b_.push_back(3);
+    b_.push_back(4);
+    b_.push_back(5);
+    r_.clear();
+    r_.push_back(5);
+    r_.push_back(6);
+    r_.push_back(7);
   }
 
-  RingBuf a{};
-  RingBuf b{};
-  RingBuf r{};
-  RingBuf&& rv = std::move(r);
+  RingBuf a_{};
+  RingBuf b_{};
+  RingBuf r_{};
+  RingBuf&& rv_ = std::move(r_);
 };
 
 using RingBufs =
@@ -75,32 +75,32 @@ TYPED_TEST(ContainerReqsGeneral, ValueInitialized) {
 }
 
 TYPED_TEST(ContainerReqsGeneral, DirectInitUnnamed) {
-  EXPECT_THAT(TypeParam(this->a), testing::ContainerEq(this->a));
+  EXPECT_THAT(TypeParam(this->a_), testing::ContainerEq(this->a_));
 }
 
 TYPED_TEST(ContainerReqsGeneral, DirectInit) {
-  TypeParam u(this->a);
-  EXPECT_THAT(u, testing::ContainerEq(this->a));
+  TypeParam u(this->a_);
+  EXPECT_THAT(u, testing::ContainerEq(this->a_));
 }
 
 TYPED_TEST(ContainerReqsGeneral, CopyInit) {
-  TypeParam u = this->a;
-  EXPECT_THAT(u, testing::ContainerEq(this->a));
+  TypeParam u = this->a_;
+  EXPECT_THAT(u, testing::ContainerEq(this->a_));
 }
 
 TYPED_TEST(ContainerReqsGeneral, DirectInitMove) {
-  TypeParam u(this->rv);
-  EXPECT_THAT(u, testing::ContainerEq(this->r));
+  TypeParam u(this->rv_);
+  EXPECT_THAT(u, testing::ContainerEq(this->r_));
 }
 
 TYPED_TEST(ContainerReqsGeneral, CopyInitMove) {
-  TypeParam u = this->rv;
-  EXPECT_THAT(u, testing::ContainerEq(this->r));
+  TypeParam u = this->rv_;
+  EXPECT_THAT(u, testing::ContainerEq(this->r_));
 }
 
 TYPED_TEST(ContainerReqsGeneral, MoveAssignment) {
-  this->a = this->rv;
-  EXPECT_THAT(this->a, testing::ContainerEq(this->r));
+  this->a_ = this->rv_;
+  EXPECT_THAT(this->a_, testing::ContainerEq(this->r_));
 }
 
 TYPED_TEST(ContainerReqsGeneral, Destructor) {
@@ -127,12 +127,12 @@ TYPED_TEST(ContainerReqsGeneral, BeginEnd) {
 }
 
 TYPED_TEST(ContainerReqsGeneral, CbeginCend) {
-  EXPECT_TYPE_EQ(decltype(this->a.cbegin()),
+  EXPECT_TYPE_EQ(decltype(this->a_.cbegin()),
                  typename TypeParam::const_iterator);
-  EXPECT_TYPE_EQ(decltype(this->a.cend()), typename TypeParam::const_iterator);
+  EXPECT_TYPE_EQ(decltype(this->a_.cend()), typename TypeParam::const_iterator);
 
-  this->a.clear();
-  EXPECT_EQ(this->a.cbegin(), this->a.cend());
+  this->a_.clear();
+  EXPECT_EQ(this->a_.cbegin(), this->a_.cend());
 }
 
 TYPED_TEST(ContainerReqsGeneral, Equality) {
@@ -166,60 +166,60 @@ TYPED_TEST(ContainerReqsGeneral, Inequality) {
 }
 
 TYPED_TEST(ContainerReqsGeneral, Swap) {
-  EXPECT_TRUE(std::is_void<decltype(this->a.swap(this->b))>::value);
+  EXPECT_TRUE(std::is_void<decltype(this->a_.swap(this->b_))>::value);
 
-  auto ax = this->a;
-  auto bx = this->b;
+  auto ax = this->a_;
+  auto bx = this->b_;
 
-  this->a.swap(this->b);
-  EXPECT_THAT(this->a, testing::Not(testing::ContainerEq(ax)));
-  EXPECT_THAT(this->b, testing::Not(testing::ContainerEq(bx)));
-  EXPECT_THAT(this->a, testing::ContainerEq(bx));
-  EXPECT_THAT(this->b, testing::ContainerEq(ax));
+  this->a_.swap(this->b_);
+  EXPECT_THAT(this->a_, testing::Not(testing::ContainerEq(ax)));
+  EXPECT_THAT(this->b_, testing::Not(testing::ContainerEq(bx)));
+  EXPECT_THAT(this->a_, testing::ContainerEq(bx));
+  EXPECT_THAT(this->b_, testing::ContainerEq(ax));
 }
 
 TYPED_TEST(ContainerReqsGeneral, StdSwap) {
-  EXPECT_TRUE(std::is_void<decltype(std::swap(this->a, this->b))>::value);
+  EXPECT_TRUE(std::is_void<decltype(std::swap(this->a_, this->b_))>::value);
 
-  auto ax = this->a;
-  auto bx = this->b;
+  auto ax = this->a_;
+  auto bx = this->b_;
 
-  std::swap(this->a, this->b);
-  EXPECT_THAT(this->a, testing::Not(testing::ContainerEq(ax)));
-  EXPECT_THAT(this->b, testing::Not(testing::ContainerEq(bx)));
-  EXPECT_THAT(this->a, testing::ContainerEq(bx));
-  EXPECT_THAT(this->b, testing::ContainerEq(ax));
+  std::swap(this->a_, this->b_);
+  EXPECT_THAT(this->a_, testing::Not(testing::ContainerEq(ax)));
+  EXPECT_THAT(this->b_, testing::Not(testing::ContainerEq(bx)));
+  EXPECT_THAT(this->a_, testing::ContainerEq(bx));
+  EXPECT_THAT(this->b_, testing::ContainerEq(ax));
 }
 
 TYPED_TEST(ContainerReqsGeneral, CopyAssignment) {
-  EXPECT_TYPE_EQ(decltype(this->r = this->a), TypeParam&);
-  this->r = this->a;
-  EXPECT_THAT(this->r, testing::ContainerEq(this->a));
+  EXPECT_TYPE_EQ(decltype(this->r_ = this->a_), TypeParam&);
+  this->r_ = this->a_;
+  EXPECT_THAT(this->r_, testing::ContainerEq(this->a_));
 }
 
 TYPED_TEST(ContainerReqsGeneral, Size) {
-  this->a.clear();
-  EXPECT_EQ(0, std::distance(this->a.begin(), this->a.end()));
-  EXPECT_EQ(0, this->a.size());
-  this->a.push_back(10);
-  EXPECT_EQ(1, std::distance(this->a.begin(), this->a.end()));
-  EXPECT_EQ(1, this->a.size());
-  this->a.push_back(20);
-  EXPECT_EQ(2, std::distance(this->a.begin(), this->a.end()));
-  EXPECT_EQ(2, this->a.size());
-  this->a.push_back(30);
-  EXPECT_EQ(2, std::distance(this->a.begin(), this->a.end()));
-  EXPECT_EQ(2, this->a.size());
+  this->a_.clear();
+  EXPECT_EQ(0, std::distance(this->a_.begin(), this->a_.end()));
+  EXPECT_EQ(0, this->a_.size());
+  this->a_.push_back(10);
+  EXPECT_EQ(1, std::distance(this->a_.begin(), this->a_.end()));
+  EXPECT_EQ(1, this->a_.size());
+  this->a_.push_back(20);
+  EXPECT_EQ(2, std::distance(this->a_.begin(), this->a_.end()));
+  EXPECT_EQ(2, this->a_.size());
+  this->a_.push_back(30);
+  EXPECT_EQ(2, std::distance(this->a_.begin(), this->a_.end()));
+  EXPECT_EQ(2, this->a_.size());
 }
 
 TYPED_TEST(ContainerReqsGeneral, MaxSize) {
-  EXPECT_EQ(this->a.max_size(), 2);
+  EXPECT_EQ(this->a_.max_size(), 2);
 }
 
 TYPED_TEST(ContainerReqsGeneral, Empty) {
-  EXPECT_FALSE(this->a.empty());
-  this->a.clear();
-  EXPECT_TRUE(this->a.empty());
+  EXPECT_FALSE(this->a_.empty());
+  this->a_.clear();
+  EXPECT_TRUE(this->a_.empty());
 }
 
 TYPED_TEST(ContainerReqsGeneral, IteratorMotion) {
@@ -239,8 +239,8 @@ TYPED_TEST(ContainerReqsGeneral, IteratorMotion) {
 }
 
 TYPED_TEST(ContainerReqsGeneral, IteratorComparison) {
-  EXPECT_TRUE(this->a.begin() == this->a.cbegin());
-  EXPECT_TRUE(this->a.cend() == this->a.end());
-  EXPECT_TRUE(this->a.cbegin() <= this->a.end());
-  EXPECT_TRUE(this->a.end() > this->a.cbegin());
+  EXPECT_TRUE(this->a_.begin() == this->a_.cbegin());
+  EXPECT_TRUE(this->a_.cend() == this->a_.end());
+  EXPECT_TRUE(this->a_.cbegin() <= this->a_.end());
+  EXPECT_TRUE(this->a_.end() > this->a_.cbegin());
 }

--- a/test/test_container_general.cpp
+++ b/test/test_container_general.cpp
@@ -200,16 +200,16 @@ TYPED_TEST(ContainerReqsGeneral, CopyAssignment) {
 TYPED_TEST(ContainerReqsGeneral, Size) {
   this->a_.clear();
   EXPECT_EQ(0, std::distance(this->a_.begin(), this->a_.end()));
-  EXPECT_EQ(0, this->a_.size());
+  EXPECT_EQ(0U, this->a_.size());
   this->a_.push_back(10);
   EXPECT_EQ(1, std::distance(this->a_.begin(), this->a_.end()));
-  EXPECT_EQ(1, this->a_.size());
+  EXPECT_EQ(1U, this->a_.size());
   this->a_.push_back(20);
   EXPECT_EQ(2, std::distance(this->a_.begin(), this->a_.end()));
-  EXPECT_EQ(2, this->a_.size());
+  EXPECT_EQ(2U, this->a_.size());
   this->a_.push_back(30);
   EXPECT_EQ(2, std::distance(this->a_.begin(), this->a_.end()));
-  EXPECT_EQ(2, this->a_.size());
+  EXPECT_EQ(2U, this->a_.size());
 }
 
 TYPED_TEST(ContainerReqsGeneral, MaxSize) {

--- a/test/test_container_general.cpp
+++ b/test/test_container_general.cpp
@@ -213,7 +213,7 @@ TYPED_TEST(ContainerReqsGeneral, Size) {
 }
 
 TYPED_TEST(ContainerReqsGeneral, MaxSize) {
-  EXPECT_EQ(this->a_.max_size(), 2);
+  EXPECT_EQ(this->a_.max_size(), 2U);
 }
 
 TYPED_TEST(ContainerReqsGeneral, Empty) {

--- a/test/test_container_general.cpp
+++ b/test/test_container_general.cpp
@@ -58,9 +58,11 @@ TYPED_TEST(ContainerReqsGeneral, TypeAliases) {
   EXPECT_TYPE_EQ(difference_type, typename const_iterator::difference_type);
 
   using size_type = typename TypeParam::size_type;
+  using unsigned_difference_type =
+      typename std::make_unsigned<difference_type>::type;
   EXPECT_TRUE(std::is_unsigned<size_type>::value);
   EXPECT_TRUE(std::numeric_limits<size_type>::max() >=
-              std::numeric_limits<difference_type>::max());
+              std::numeric_limits<unsigned_difference_type>::max());
 }
 
 TYPED_TEST(ContainerReqsGeneral, DefaultInitialized) {

--- a/test/test_container_reversible.cpp
+++ b/test/test_container_reversible.cpp
@@ -1,16 +1,13 @@
-#include <baudvine/ringbuf/deque_ringbuf.h>
-#include <baudvine/ringbuf/ringbuf.h>
+#include "ringbufs.h"
 
 #include <gtest/gtest.h>
-#include <iterator>
 
 #define EXPECT_TYPE_EQ(T1, T2) EXPECT_TRUE((std::is_same<T1, T2>::value))
 
 template <typename RingBuf>
 class ContainerReversible : public testing::Test {};
 
-using RingBufs =
-    testing::Types<baudvine::RingBuf<int, 2>, baudvine::DequeRingBuf<int, 2>>;
+using RingBufs = AllRingBufs<int, 2>;
 // NOLINTNEXTLINE - clang-tidy complains about missing variadic args
 TYPED_TEST_SUITE(ContainerReversible, RingBufs);
 

--- a/test/test_container_sequence.cpp
+++ b/test/test_container_sequence.cpp
@@ -15,7 +15,7 @@ TYPED_TEST_SUITE(ContainerSequence, RingBufs);
 
 TYPED_TEST(ContainerSequence, EraseSingle) {
   TypeParam underTest;
-  for (size_t i = 0; i < underTest.max_size() + 2; i++) {
+  for (uint16_t i = 0; i < underTest.max_size() + 2; i++) {
     underTest.push_back(i * 2);
   }
 
@@ -43,7 +43,7 @@ TYPED_TEST(ContainerSequence, EraseSingle) {
 TYPED_TEST(ContainerSequence, EraseRange) {
   TypeParam original;
   // 4 6 8 10 12
-  for (size_t i = 0; i < original.max_size() + 2; i++) {
+  for (uint16_t i = 0; i < original.max_size() + 2; i++) {
     original.push_back(i * 2);
   }
 
@@ -82,7 +82,7 @@ TYPED_TEST(ContainerSequence, EraseRange) {
 
 TYPED_TEST(ContainerSequence, EraseSmallRangeInLowerMiddle) {
   RingBufAdapter<TypeParam, int, 7> underTest;
-  for (size_t i = 0; i < underTest.max_size() + 2; i++) {
+  for (uint16_t i = 0; i < underTest.max_size() + 2; i++) {
     underTest.push_back(i * 2);
   }
   // the important bit here is that the range is in the bottom half, and shorter
@@ -94,7 +94,7 @@ TYPED_TEST(ContainerSequence, EraseSmallRangeInLowerMiddle) {
 
 TYPED_TEST(ContainerSequence, EraseSmallRangeInUpperMiddle) {
   RingBufAdapter<TypeParam, int, 7> underTest;
-  for (size_t i = 0; i < underTest.max_size() + 2; i++) {
+  for (uint16_t i = 0; i < underTest.max_size() + 2; i++) {
     underTest.push_back(i * 2);
   }
   // the important bit here is that the range is in the upper half, and shorter
@@ -106,7 +106,7 @@ TYPED_TEST(ContainerSequence, EraseSmallRangeInUpperMiddle) {
 
 TYPED_TEST(ContainerSequence, Front) {
   TypeParam underTest;
-  for (size_t i = 0; i < underTest.max_size() + 2; i++) {
+  for (uint16_t i = 0; i < underTest.max_size() + 2; i++) {
     underTest.push_back(i * 2);
   }
 
@@ -121,7 +121,7 @@ TYPED_TEST(ContainerSequence, Front) {
 
 TYPED_TEST(ContainerSequence, Back) {
   TypeParam underTest;
-  for (size_t i = 0; i < underTest.max_size() + 2; i++) {
+  for (uint16_t i = 0; i < underTest.max_size() + 2; i++) {
     underTest.push_back(i * 2);
   }
 
@@ -176,7 +176,7 @@ TYPED_TEST(ContainerSequence, PushBack) {
 
 TYPED_TEST(ContainerSequence, PopFront) {
   TypeParam underTest;
-  for (size_t i = 0; i < underTest.max_size() + 2; i++) {
+  for (uint16_t i = 0; i < underTest.max_size() + 2; i++) {
     underTest.push_back(i * 2);
   }
   underTest.pop_front();
@@ -185,7 +185,7 @@ TYPED_TEST(ContainerSequence, PopFront) {
 
 TYPED_TEST(ContainerSequence, PopBack) {
   TypeParam underTest;
-  for (size_t i = 0; i < underTest.max_size() + 2; i++) {
+  for (uint16_t i = 0; i < underTest.max_size() + 2; i++) {
     underTest.push_back(i * 2);
   }
   underTest.pop_back();
@@ -194,7 +194,7 @@ TYPED_TEST(ContainerSequence, PopBack) {
 
 TYPED_TEST(ContainerSequence, Subscript) {
   TypeParam underTest;
-  for (size_t i = 0; i < underTest.max_size() + 2; i++) {
+  for (uint16_t i = 0; i < underTest.max_size() + 2; i++) {
     underTest.push_back(i * 2);
   }
   EXPECT_EQ(underTest[0], 4);
@@ -213,7 +213,7 @@ TYPED_TEST(ContainerSequence, At) {
   EXPECT_THROW(underTest.at(1), std::out_of_range);
   EXPECT_THROW(underTest.at(4), std::out_of_range);
 
-  for (size_t i = 0; i < underTest.max_size() + 2; i++) {
+  for (uint16_t i = 0; i < underTest.max_size() + 2; i++) {
     underTest.push_back(i * 2);
   }
   EXPECT_EQ(underTest.at(0), 4);

--- a/test/test_container_sequence.cpp
+++ b/test/test_container_sequence.cpp
@@ -224,7 +224,8 @@ TYPED_TEST(ContainerSequence, At) {
   EXPECT_EQ(underTest.at(1), 555);
 
   EXPECT_THROW(underTest.at(5), std::out_of_range);
-  EXPECT_THROW(underTest.at(-1), std::out_of_range);
+  EXPECT_THROW(underTest.at(static_cast<typename TypeParam::size_type>(-1)),
+               std::out_of_range);
 }
 
 TYPED_TEST(ContainerSequence, AtConstEmpty) {

--- a/test/test_exception_safety.cpp
+++ b/test/test_exception_safety.cpp
@@ -1,4 +1,5 @@
 #include "ringbuf_adapter.h"
+#include "ringbufs.h"
 
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
@@ -10,8 +11,7 @@
 template <typename T>
 class ExceptionSafety : public testing::Test {};
 
-using RingBufs =
-    testing::Types<baudvine::RingBuf<int, 2>, baudvine::DequeRingBuf<int, 2>>;
+using RingBufs = AllRingBufs<int, 2>;
 // NOLINTNEXTLINE - clang-tidy complains about missing variadic args
 TYPED_TEST_SUITE(ExceptionSafety, RingBufs);
 

--- a/test/test_iterator_rando.cpp
+++ b/test/test_iterator_rando.cpp
@@ -1,4 +1,5 @@
 #include "ringbuf_adapter.h"
+#include "ringbufs.h"
 
 #include <gtest/gtest.h>
 
@@ -29,8 +30,7 @@ class IteratorRando : public testing::Test {
   D n_;
 };
 
-using RingBufs =
-    testing::Types<baudvine::RingBuf<int, 4>, baudvine::DequeRingBuf<int, 4>>;
+using RingBufs = AllRingBufs<int, 4>;
 // NOLINTNEXTLINE - clang-tidy complains about missing variadic args
 TYPED_TEST_SUITE(IteratorRando, RingBufs);
 

--- a/test/test_iterator_rando.cpp
+++ b/test/test_iterator_rando.cpp
@@ -11,8 +11,8 @@ class IteratorRando : public testing::Test {
  protected:
   void SetUp() override {
     // Add some extra so end() is before begin() in the backing storage
-    const int count = ringbuf_.max_size() + 3;
-    for (int i = 0; i < count; i++) {
+    const size_t count = ringbuf_.max_size() + 3;
+    for (uint16_t i = 0; i < count; i++) {
       ringbuf_.push_back(i);
     }
     a_ = ringbuf_.begin();

--- a/test/test_ringbuf.cpp
+++ b/test/test_ringbuf.cpp
@@ -1,5 +1,6 @@
 #include "instance_counter.h"
 #include "ringbuf_adapter.h"
+#include "ringbufs.h"
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -10,8 +11,7 @@
 template <typename T>
 class RingBuf : public testing::Test {};
 
-using RingBufs =
-    testing::Types<baudvine::RingBuf<int, 2>, baudvine::DequeRingBuf<int, 2>>;
+using RingBufs = AllRingBufs<int, 2>;
 // NOLINTNEXTLINE - clang-tidy complains about missing variadic args
 TYPED_TEST_SUITE(RingBuf, RingBufs);
 

--- a/test/test_speed.cpp
+++ b/test/test_speed.cpp
@@ -24,7 +24,7 @@ std::chrono::system_clock::duration TimeIt(const std::function<void()>& fn) {
   const auto start = std::chrono::system_clock::now();
   fn();
   return std::chrono::system_clock::now() - start;
-};
+}
 }  // namespace
 
 TEST(Speed, PushBackToFull) {


### PR DESCRIPTION
The custom allocator tests now use `std::vector<boost::ipc::string>` (well, one of them does because the test names are long enough already).