### PR TITLE
Feature/trivial elements

### DIFF
--- a/test/test_speed.cpp
+++ b/test/test_speed.cpp
@@ -58,7 +58,7 @@ TEST(Speed, PushBackToFull) {
   std::cout << "DequeRingBuf: " << dequeDuration << std::endl;
 }
 
-TEST(Speed, PushBackOverFull) {
+TEST(Speed, PushBackOverFullTrivial) {
   baudvine::RingBuf<uint64_t, 3> standard;
   baudvine::DequeRingBuf<uint64_t, 3> deque;
 
@@ -71,6 +71,27 @@ TEST(Speed, PushBackOverFull) {
   auto dequeDuration = TimeIt([&deque] {
     for (uint32_t i = 0; i < kTestSize; i++) {
       deque.push_back(0);
+    }
+  });
+
+  EXPECT_LT(standardDuration, dequeDuration);
+  std::cout << "RingBuf:      " << standardDuration << std::endl;
+  std::cout << "DequeRingBuf: " << dequeDuration << std::endl;
+}
+
+TEST(Speed, PushBackOverFullString) {
+  baudvine::RingBuf<std::string, 3> standard;
+  baudvine::DequeRingBuf<std::string, 3> deque;
+
+  auto standardDuration = TimeIt([&standard] {
+    for (uint32_t i = 0; i < kTestSize; i++) {
+      standard.push_back({});
+    }
+  });
+
+  auto dequeDuration = TimeIt([&deque] {
+    for (uint32_t i = 0; i < kTestSize; i++) {
+      deque.push_back({});
     }
   });
 


### PR DESCRIPTION
An attempt to provide faster implementations of emplace & pop when `Elem` is trivial. Will probably not merge this, as the perf benefit is hard to confirm and it probably makes compile times worse. I guess std::allocator_traits is reasonably smart about this.