### PR TITLE
Speed test improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,19 +131,18 @@ comparisons between `RingBuf` and `DequeRingBuf`. Some typical (but completely
 unscientific) results:
 
 - Hardware: Intel Core i5-7600 @ 3.5 GHz
-- GCC: 11.2, `-O3 -DNDEBUG`
-- Clang: 11.1, `-O3 -DNDEBUG`
+- GCC: 12.2, `-O3 -DNDEBUG`
+- Clang: 14.0, `-O3 -DNDEBUG`
 
 | Name | Description | RingBuf (GCC) (ms) | RingBuf (Clang) (ms) | DequeRingBuf (GCC) (ms) | DequeRingBuf (Clang) (ms) |
 |------|-------------|-------------------:|---------------------:|------------------------:|--------------------------:|
-| PushBackToFull | `push_back` until the buffer is filled to capacity (2<sup>25</sup> elements) | 130 | 60 | 160 | 160 |
-| PushBackOverFull | `push_back` 2<sup>25</sup> times on a buffer with capacity 3 | 132 | 63 | 86 | 91 |
-| IterateOver | range-for over a buffer with 2<sup>25</sup> elements | 21 | 20 | 48 | 19 |
+| PushBackToFull | `push_back` until the buffer is filled to capacity (2<sup>25</sup> elements) | 106 | 108 | 353 | 322 |
+| PushBackOverFull | `push_back` 2<sup>25</sup> times on a buffer with capacity 3 | 119 | 105 | 138 | 195 |
+| IterateOver | range-for over a buffer with 2<sup>25</sup> elements | 83 | 57 | 77 | 72 |
 
 PushBackToFull is *completely* unfair because `std::deque` has to allocate
 memory much more frequently. In a debug build, the results are roughly
-proportional (~10x), although `baudvine::RingBuf` does comparatively worse in
-IterateOver.
+proportional (~10x).
 
 ## FAQ
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,6 +5,7 @@ file(GLOB test_files "test_*.cpp")
 target_sources(ringbuf-test PRIVATE
         examples.cpp
         instance_counter.cpp
+        black_box.cpp
         ${test_files}
         )
 

--- a/test/black_box.cpp
+++ b/test/black_box.cpp
@@ -1,0 +1,7 @@
+#include "black_box.h"
+
+uint64_t black_box(uint64_t input) {
+  return input;
+}
+
+void do_nothing(const void* /*nothing*/) {}

--- a/test/black_box.h
+++ b/test/black_box.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <cstdint>
+
+// Some functions that do very little but should prevent the compiler from
+// optimizing the entire speed test away.
+
+uint64_t black_box(uint64_t input);
+void do_nothing(const void* nothing);


### PR DESCRIPTION
Less trying to trick the compiler and more taking advantage of not turning on LTO. The results seem roughly proportional, all the same.